### PR TITLE
feat(dashboard): 更新 MudBlazor 组件属性与布局结构

### DIFF
--- a/src/Dpz.Core.Web.Dashboard/Pages/AudioPage/Music/Add.razor
+++ b/src/Dpz.Core.Web.Dashboard/Pages/AudioPage/Music/Add.razor
@@ -3,8 +3,10 @@
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="music-container">
     <MudPaper Class="music-hero pa-6 mb-6" Elevation="1">
-        <MudStack Direction="Row" Spacing="3" AlignItems="AlignItems.Center">
-            <MudAvatar Icon="@Icons.Material.Filled.LibraryMusic" Size="Size.Large" Class="music-hero__avatar"/>
+        <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Center">
+            <MudAvatar Size="Size.Large" Class="music-hero__avatar">
+                <MudIcon Icon="@Icons.Material.Filled.Album" Size="Size.Large" />
+            </MudAvatar>
             <MudStack Spacing="1">
                 <MudText Typo="Typo.h4" Class="music-hero__title">添加音乐</MudText>
                 <MudText Typo="Typo.subtitle1" Class="music-hero__subtitle">上传音频、封面与歌词，一次性完成音乐素材的整理</MudText>
@@ -24,7 +26,7 @@
                     <MudStack Spacing="4">
                         <section class="upload-block">
                             <InputFile OnChange="OnMusicChanged" id="fileMusic" hidden accept="@(string.Join(',', _musicExtensions.Select(x => '.' + x)))"/>
-                            <MudStack Direction="Row" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="upload-block__header">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="upload-block__header">
                                 <MudStack Spacing="1">
                                     <MudText Typo="Typo.h6">音频文件</MudText>
                                     <MudText Typo="Typo.body2" Class="upload-block__hint">支持批量选择，自动识别格式与大小</MudText>
@@ -66,7 +68,7 @@
 
                         <section class="upload-block">
                             <InputFile OnChange="OnCoverChanged" id="fileCover" hidden accept="@(string.Join(',', AppTools.ImageExtensions.Select(x => '.' + x)))"/>
-                            <MudStack Direction="Row" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="upload-block__header">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="upload-block__header">
                                 <MudStack Spacing="1">
                                     <MudText Typo="Typo.h6">封面图片</MudText>
                                     <MudText Typo="Typo.body2" Class="upload-block__hint">推荐上传正方形高清封面，自动预览效果</MudText>
@@ -111,7 +113,7 @@
 
                         <section class="upload-block">
                             <InputFile OnChange="OnLrcChanged" id="fileLrc" hidden accept=".lrc"/>
-                            <MudStack Direction="Row" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="upload-block__header">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="upload-block__header">
                                 <MudStack Spacing="1">
                                     <MudText Typo="Typo.h6">歌词文件</MudText>
                                     <MudText Typo="Typo.body2" Class="upload-block__hint">支持标准 .LRC 歌词文件，自动展示文本</MudText>
@@ -177,7 +179,7 @@
                             </MudTextField>
                         </section>
 
-                        <MudStack Direction="Row" Justify="Justify.FlexEnd" Spacing="2" Class="actions-row">
+                        <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2" Class="actions-row">
                             <MudButton Variant="Variant.Outlined" Color="Color.Default" Href="/music">返回列表</MudButton>
                             <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Disabled="_isPosting" Color="Color.Primary" Class="submit-button">
                                 @if (_isPosting)

--- a/src/Dpz.Core.Web.Dashboard/Pages/AudioPage/Music/Detail.razor
+++ b/src/Dpz.Core.Web.Dashboard/Pages/AudioPage/Music/Detail.razor
@@ -3,8 +3,10 @@
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="music-container">
     <MudPaper Class="music-hero pa-6 mb-6" Elevation="1">
-        <MudStack Direction="Row" Spacing="3" AlignItems="AlignItems.Center">
-            <MudAvatar Icon="@Icons.Material.Filled.Album" Size="Size.Large" Class="music-hero__avatar"/>
+        <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Center">
+            <MudAvatar Size="Size.Large" Class="music-hero__avatar">
+                <MudIcon Icon="@Icons.Material.Filled.Album" Size="Size.Large" />
+            </MudAvatar>
             <MudStack Spacing="1">
                 <MudText Typo="Typo.h4" Class="music-hero__title">音乐详情</MudText>
                 <MudText Typo="Typo.subtitle1" Class="music-hero__subtitle">
@@ -21,7 +23,7 @@
                 <MudSkeleton Width="30%" Height="42px"/>
                 <MudSkeleton Width="80%" Height="24px"/>
                 <MudSkeleton Width="100%" Height="160px"/>
-                <MudStack Direction="Row" Spacing="2">
+                <MudStack Row="true" Spacing="2">
                     <MudSkeleton Width="120px" Height="40px"/>
                     <MudSkeleton Width="140px" Height="40px"/>
                 </MudStack>
@@ -73,7 +75,7 @@
                             <section class="upload-block">
                                 <InputFile OnChange="OnCoverChanged" id="fileCover" hidden
                                            accept="@(string.Join(',', AppTools.ImageExtensions.Select(x => '.' + x)))"/>
-                                <MudStack Direction="Row" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween"
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween"
                                           Class="upload-block__header">
                                     <MudStack Spacing="1">
                                         <MudText Typo="Typo.h6">封面图片</MudText>
@@ -125,7 +127,7 @@
 
                             <section class="upload-block">
                                 <InputFile OnChange="OnLrcChanged" id="fileLrc" hidden accept=".lrc"/>
-                                <MudStack Direction="Row" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween"
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween"
                                           Class="upload-block__header">
                                     <MudStack Spacing="1">
                                         <MudText Typo="Typo.h6">歌词文件</MudText>
@@ -196,7 +198,7 @@
                                 </MudTextField>
                             </section>
 
-                            <MudStack Direction="Row" Justify="Justify.FlexEnd" Spacing="2" Class="actions-row">
+                            <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2" Class="actions-row">
                                 <MudButton Variant="Variant.Outlined" Color="Color.Default" Href="/music">返回列表
                                 </MudButton>
                                 <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Disabled="_isPosting"

--- a/src/Dpz.Core.Web.Dashboard/Shared/MainLayout.razor
+++ b/src/Dpz.Core.Web.Dashboard/Shared/MainLayout.razor
@@ -5,10 +5,10 @@
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject NavigationManager Navigation
 
-<MudThemeProvider @ref="@_mudThemeProvider" IsDarkMode="@_isDarkMode" />
-<MudPopoverProvider />
-<MudDialogProvider />
-<MudSnackbarProvider />
+<MudThemeProvider @ref="@_mudThemeProvider" IsDarkMode="@_isDarkMode"/>
+<MudPopoverProvider/>
+<MudDialogProvider/>
+<MudSnackbarProvider/>
 
 <MudLayout>
     <MudAppBar Elevation="25">
@@ -16,7 +16,8 @@
             <img src="https://dpangzi.com/core/images/Lara-Croft.png" style="width: 50px" alt="logo"/>
         </MudHidden>
         <MudHidden Breakpoint="Breakpoint.MdAndUp">
-            <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+            <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Edge="Edge.Start"
+                           OnClick="@((e) => DrawerToggle())"/>
         </MudHidden>
         <MudHidden Breakpoint="Breakpoint.Xs">
             <MudText Typo="Typo.h6" Class="ml-4">后台管理系统</MudText>
@@ -24,15 +25,22 @@
         <MudHidden Breakpoint="Breakpoint.Xs" Invert="true">
             <MudText Typo="Typo.subtitle2">后台管理系统</MudText>
         </MudHidden>
-        <MudSpacer />
+        <MudSpacer/>
         @* <MudMenu Icon="@Icons.Material.Outlined.Translate" Color="Color.Inherit" AnchorOrigin="Origin.BottomCenter"  Dense="true"> *@
         @*     <MudMenuItem>简体中文</MudMenuItem> *@
         @* </MudMenu> *@
-        <MudMenu Icon="@Icons.Material.Outlined.Widgets" Color="Color.Inherit" AnchorOrigin="Origin.BottomCenter"  Dense="true">
-            <MudMenuItem Icon="@Icons.Material.Outlined.Domain" Href="https://core.dpangzi.com" Target="_blank">Core站点</MudMenuItem>
-            <MudMenuItem Icon="@Icons.Material.Outlined.Domain" Href="https://www.dpangzi.com" Target="_blank">主站点</MudMenuItem>
-            <MudMenuItem Icon="@Icons.Material.Outlined.EventNote" Href="https://www.dpangzi.com" Target="_blank">日志</MudMenuItem>
-            <MudMenuItem Icon="@Icons.Material.Outlined.SettingsApplications" Href="https://config.dpangzi.com" Target="_blank">系统配置</MudMenuItem>
+        <MudMenu Icon="@Icons.Material.Outlined.Widgets" Color="Color.Inherit" AnchorOrigin="Origin.BottomCenter"
+                 Dense="true">
+            <MudMenuItem Icon="@Icons.Material.Outlined.Domain" Href="https://core.dpangzi.com" Target="_blank">
+                Core站点
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Outlined.Domain" Href="https://www.dpangzi.com" Target="_blank">主站点
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Outlined.EventNote" Href="https://www.dpangzi.com" Target="_blank">日志
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Outlined.SettingsApplications" Href="https://config.dpangzi.com"
+                         Target="_blank">系统配置
+            </MudMenuItem>
         </MudMenu>
         <AuthorizeView>
             <Authorized Context="auth">
@@ -43,17 +51,20 @@
                         }
                         @if (!string.IsNullOrWhiteSpace(avatar))
                         {
-                            <MudImage Src="@avatar" Style="width: 24px;height: 24px" />
+                            <MudImage Src="@avatar" Style="width: 24px;height: 24px"/>
                         }
                         else
                         {
-                            <MudAvatar Size="Size.Medium" Icon="@Icons.Material.Outlined.Person" />
+                            <MudAvatar Size="Size.Medium">
+                                <MudIcon Icon="@Icons.Material.Outlined.Person"></MudIcon>
+                            </MudAvatar>
                         }
                     </ActivatorContent>
                     <ChildContent>
-                        <PersonCard Class="mt-n2" />
-                        <MudDivider Class="mb-2" />
-                        <MudListItem T="string" Text="注销" Icon="@Icons.Material.Outlined.Login" OnClick="BeginLogout" />
+                        <PersonCard Class="mt-n2"/>
+                        <MudDivider Class="mb-2"/>
+                        <MudListItem T="string" Text="注销" Icon="@Icons.Material.Outlined.Login"
+                                     OnClick="BeginLogout"/>
                     </ChildContent>
                 </MudMenu>
             </Authorized>
@@ -61,19 +72,21 @@
                 @{
                     var returnUrl = Uri.EscapeDataString(Navigation.Uri);
                 }
-                <MudButton Variant="Variant.Text" Href="@($"/authentication/login?returnUrl={returnUrl}")">登录</MudButton>
+                <MudButton Variant="Variant.Text" Href="@($"/authentication/login?returnUrl={returnUrl}")">登录
+                </MudButton>
             </NotAuthorized>
         </AuthorizeView>
     </MudAppBar>
     <MudDrawer @bind-Open="_drawerOpen" Elevation="25" ClipMode="DrawerClipMode.Always">
-        <NavMenu />
+        <NavMenu/>
     </MudDrawer>
     <MudMainContent>
         <MudHidden Breakpoint="Breakpoint.SmAndDown">
             <MudToolBar Gutters="false">
-                <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" OnClick="@((e) => DrawerToggle())" Class="ml-3" />
+                <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit"
+                               OnClick="@((e) => DrawerToggle())" Class="ml-3"/>
                 @*<MudBreadcrumbs Items="_items"></MudBreadcrumbs>*@
-                <MudSpacer />
+                <MudSpacer/>
             </MudToolBar>
         </MudHidden>
         <MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
@@ -85,9 +98,9 @@
 
 @code {
     //private MudBlazorAdminDashboard _theme = new();
-    
+
     private bool _isDarkMode;
-    
+
     private MudThemeProvider _mudThemeProvider;
 
     private bool _drawerOpen = true;
@@ -118,6 +131,7 @@
             //     _mudThemeProvider.Theme = new MudBlazorAdminDashboard();
             StateHasChanged();
         }
+
         await base.OnAfterRenderAsync(firstRender);
     }
 
@@ -126,7 +140,7 @@
     //    new BreadcrumbItem("Personal", href: "#"),
     //    new BreadcrumbItem("Dashboard", href: "#"),
     //};
-    
+
     private Task BeginLogout()
     {
         var returnUrl = Uri.EscapeDataString(Navigation.Uri);


### PR DESCRIPTION
- 将 MudStack 的 Direction 属性替换为 Row 属性以适配新版本
- 更新 MudAvatar 内图标使用方式，采用 MudIcon 子组件形式
- 调整多个页面中 MudStack、MudAvatar 和其他组件的属性写法
- 优化 MainLayout 中菜单项和按钮的标签换行显示
- 统一缩进与空格格式，提升代码可读性
- 修正部分组件自闭合标签的书写风格